### PR TITLE
fix: support separate sso and default aws regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,19 +158,25 @@ spinner_color = "#42f551"
 [organizations.org1]
 url = "https://org1.awsapps.com/start"
 prefix = "org1"
-region = "us-east-1"
+sso_region = "us-east-1"
+default_region = "us-west-2"
 
 [organizations.org2]
 url = "https://org2.awsapps.com/start"
 prefix = "org2"
-region = "us-west-2"
+sso_region = "us-west-2"
 ```
 
 Each organization entry must have:
 
 - url: The awsapps URL to interact with the AWS SSO/Identity Center Org
 - prefix: A prefix to identify profiles in the aws local config files
-- region: The region of the AWS SSO/Identity Center Org
+- sso_region: The region of the AWS SSO/Identity Center Org
+
+Optional organization fields:
+
+- default_region: The default AWS region written to generated profiles. If omitted, it falls back to `sso_region`.
+- region: Legacy compatibility fallback for older configs. If `sso_region` is missing, `region` is treated as the SSO region.
 
 You can create or update this config interactively with:
 
@@ -183,7 +189,8 @@ aws-sso-creds init
 - organization name
 - AWS start URL
 - prefix
-- region
+- SSO region
+- default AWS region, optional
 
 The command also validates that the color entries are written in `hex` notation, so the generated config stays usable without manual cleanup.
 

--- a/cmd/aws-sso-creds/init.go
+++ b/cmd/aws-sso-creds/init.go
@@ -101,16 +101,21 @@ func runInitCommand(deps initDeps) error {
 	if err != nil {
 		return err
 	}
-	region, err := prompts.promptValue("Region", validateNonEmpty)
+	ssoRegion, err := prompts.promptValue("SSO region", validateNonEmpty)
+	if err != nil {
+		return err
+	}
+	defaultRegion, err := prompts.promptValue("Default AWS region (optional, press enter to use the SSO region)", nil)
 	if err != nil {
 		return err
 	}
 
 	if err := deps.upsertOrg(configPath, config.Organization{
-		Name:   name,
-		URL:    startURL,
-		Prefix: prefix,
-		Region: region,
+		Name:          name,
+		URL:           startURL,
+		Prefix:        prefix,
+		SSORegion:     ssoRegion,
+		DefaultRegion: defaultRegion,
 	}); err != nil {
 		return err
 	}

--- a/cmd/aws-sso-creds/init_test.go
+++ b/cmd/aws-sso-creds/init_test.go
@@ -53,7 +53,7 @@ func TestInitCommandCreatesOrganizationConfig(t *testing.T) {
 	configPath = filepath.Join(t.TempDir(), "aws-sso-creds.toml")
 	var out bytes.Buffer
 	cmd := newInitCmd(initDeps{
-		in:        strings.NewReader("dev\nhttps://dev.awsapps.com/start\ndev\nus-east-1\n"),
+		in:        strings.NewReader("dev\nhttps://dev.awsapps.com/start\ndev\nus-east-1\n\n"),
 		out:       &out,
 		upsertOrg: config.UpsertOrganizationConfig,
 		fileExists: func(string) bool {
@@ -75,6 +75,9 @@ func TestInitCommandCreatesOrganizationConfig(t *testing.T) {
 	if got := config.GetInstance().Orgs["dev"].Prefix; got != "dev" {
 		t.Fatalf("prefix = %q, want dev", got)
 	}
+	if got := config.GetInstance().Orgs["dev"].EffectiveSSORegion(); got != "us-east-1" {
+		t.Fatalf("EffectiveSSORegion() = %q, want us-east-1", got)
+	}
 }
 
 func TestInitCommandUpdatesExistingOrganization(t *testing.T) {
@@ -90,7 +93,7 @@ region = "us-west-1"
 
 	var out bytes.Buffer
 	cmd := newInitCmd(initDeps{
-		in:        strings.NewReader("dev\nhttps://dev.awsapps.com/start\ndev\nus-east-1\n"),
+		in:        strings.NewReader("dev\nhttps://dev.awsapps.com/start\ndev\nus-east-1\nus-west-2\n"),
 		out:       &out,
 		upsertOrg: config.UpsertOrganizationConfig,
 		fileExists: func(string) bool {
@@ -109,8 +112,11 @@ region = "us-west-1"
 	if err := config.Init(t.TempDir(), configPath); err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
-	if got := config.GetInstance().Orgs["dev"].Region; got != "us-east-1" {
-		t.Fatalf("region = %q, want us-east-1", got)
+	if got := config.GetInstance().Orgs["dev"].EffectiveSSORegion(); got != "us-east-1" {
+		t.Fatalf("EffectiveSSORegion() = %q, want us-east-1", got)
+	}
+	if got := config.GetInstance().Orgs["dev"].EffectiveDefaultRegion(); got != "us-west-2" {
+		t.Fatalf("EffectiveDefaultRegion() = %q, want us-west-2", got)
 	}
 }
 
@@ -127,7 +133,7 @@ region = "eu-west-1"
 
 	var out bytes.Buffer
 	cmd := newInitCmd(initDeps{
-		in:        strings.NewReader("dev\nhttps://shared.awsapps.com/start\ndev\nus-east-1\n"),
+		in:        strings.NewReader("dev\nhttps://shared.awsapps.com/start\ndev\nus-east-1\n\n"),
 		out:       &out,
 		upsertOrg: config.UpsertOrganizationConfig,
 		fileExists: func(string) bool {
@@ -138,6 +144,39 @@ region = "eu-west-1"
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), `already uses start URL`) {
 		t.Fatalf("Execute() error = %v, want duplicate URL conflict", err)
+	}
+}
+
+func TestInitCommandWritesExplicitSSORegionWithoutDefaultRegionWhenBlank(t *testing.T) {
+	configPath = filepath.Join(t.TempDir(), "aws-sso-creds.toml")
+	var out bytes.Buffer
+	cmd := newInitCmd(initDeps{
+		in:        strings.NewReader("dev\nhttps://dev.awsapps.com/start\ndev\nus-east-1\n\n"),
+		out:       &out,
+		upsertOrg: config.UpsertOrganizationConfig,
+		fileExists: func(string) bool {
+			return false
+		},
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	text := string(raw)
+	if !strings.Contains(text, `sso_region = "us-east-1"`) {
+		t.Fatalf("config = %q, want sso_region", text)
+	}
+	if strings.Contains(text, "default_region") {
+		t.Fatalf("config = %q, did not want default_region", text)
+	}
+	if strings.Contains(text, "\nregion = ") {
+		t.Fatalf("config = %q, did not want legacy region key", text)
 	}
 }
 

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -27,10 +27,26 @@ var c *Config
 var lock = &sync.Mutex{}
 
 type Organization struct {
-	Name   string `validate:"required"`
-	Prefix string `validate:"required" mapstructure:"prefix"`
-	URL    string `validate:"required" mapstructure:"url"`
-	Region string `validate:"required" mapstructure:"region"`
+	Name          string `validate:"required"`
+	Prefix        string `validate:"required" mapstructure:"prefix"`
+	URL           string `validate:"required" mapstructure:"url"`
+	Region        string `mapstructure:"region"`
+	SSORegion     string `mapstructure:"sso_region"`
+	DefaultRegion string `mapstructure:"default_region"`
+}
+
+func (o Organization) EffectiveSSORegion() string {
+	if o.SSORegion != "" {
+		return o.SSORegion
+	}
+	return o.Region
+}
+
+func (o Organization) EffectiveDefaultRegion() string {
+	if o.DefaultRegion != "" {
+		return o.DefaultRegion
+	}
+	return o.EffectiveSSORegion()
 }
 
 func setDefaults() {
@@ -130,7 +146,13 @@ func UpsertOrganizationConfig(configPath string, org Organization) error {
 	orgPath := fmt.Sprintf("organizations.%s", org.Name)
 	tree.Set(fmt.Sprintf("%s.url", orgPath), org.URL)
 	tree.Set(fmt.Sprintf("%s.prefix", orgPath), org.Prefix)
-	tree.Set(fmt.Sprintf("%s.region", orgPath), org.Region)
+	tree.Delete(fmt.Sprintf("%s.region", orgPath))
+	tree.Delete(fmt.Sprintf("%s.sso_region", orgPath))
+	tree.Delete(fmt.Sprintf("%s.default_region", orgPath))
+	tree.Set(fmt.Sprintf("%s.sso_region", orgPath), org.EffectiveSSORegion())
+	if org.DefaultRegion != "" && org.DefaultRegion != org.EffectiveSSORegion() {
+		tree.Set(fmt.Sprintf("%s.default_region", orgPath), org.DefaultRegion)
+	}
 
 	return os.WriteFile(configPath, []byte(tree.String()), 0o644)
 }
@@ -161,6 +183,11 @@ func Init(home string, configPath string) error {
 		validate := validator.New()
 		if err := validate.Struct(&aux); err != nil {
 			return fmt.Errorf("Missing required attributes %v\n", err)
+		}
+		for name, org := range aux.Orgs {
+			if org.EffectiveSSORegion() == "" {
+				return fmt.Errorf("Missing required attributes organizations.%s.sso_region\n", name)
+			}
 		}
 		c = &aux
 	}

--- a/internal/app/config/config_test.go
+++ b/internal/app/config/config_test.go
@@ -42,6 +42,65 @@ region = "us-east-1"
 	}
 }
 
+func TestInitSupportsExplicitSSOAndDefaultRegions(t *testing.T) {
+	ResetForTest()
+
+	home := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "aws-sso-creds.toml")
+	err := os.WriteFile(configPath, []byte(`
+[organizations.dev]
+url = "https://dev.awsapps.com/start"
+prefix = "dev"
+sso_region = "us-east-1"
+default_region = "eu-west-1"
+`), 0o644)
+	if err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	err = Init(home, configPath)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	org := GetInstance().Orgs["dev"]
+	if got := org.EffectiveSSORegion(); got != "us-east-1" {
+		t.Fatalf("EffectiveSSORegion() = %q, want %q", got, "us-east-1")
+	}
+	if got := org.EffectiveDefaultRegion(); got != "eu-west-1" {
+		t.Fatalf("EffectiveDefaultRegion() = %q, want %q", got, "eu-west-1")
+	}
+}
+
+func TestInitUsesLegacyRegionAsSSORegionFallback(t *testing.T) {
+	ResetForTest()
+
+	home := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "aws-sso-creds.toml")
+	err := os.WriteFile(configPath, []byte(`
+[organizations.dev]
+url = "https://dev.awsapps.com/start"
+prefix = "dev"
+region = "us-east-1"
+`), 0o644)
+	if err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	err = Init(home, configPath)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	org := GetInstance().Orgs["dev"]
+	if got := org.EffectiveSSORegion(); got != "us-east-1" {
+		t.Fatalf("EffectiveSSORegion() = %q, want %q", got, "us-east-1")
+	}
+	if got := org.EffectiveDefaultRegion(); got != "us-east-1" {
+		t.Fatalf("EffectiveDefaultRegion() = %q, want %q", got, "us-east-1")
+	}
+}
+
 func TestInitReturnsErrorForMissingOrganizationFields(t *testing.T) {
 	ResetForTest()
 

--- a/internal/app/config/config_writer_test.go
+++ b/internal/app/config/config_writer_test.go
@@ -3,16 +3,17 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestUpsertOrganizationConfigCreatesNewConfigWithDefaults(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "nested", "aws-sso-creds.toml")
 	err := UpsertOrganizationConfig(configPath, Organization{
-		Name:   "dev",
-		URL:    "https://dev.awsapps.com/start",
-		Prefix: "dev",
-		Region: "us-east-1",
+		Name:      "dev",
+		URL:       "https://dev.awsapps.com/start",
+		Prefix:    "dev",
+		SSORegion: "us-east-1",
 	})
 	if err != nil {
 		t.Fatalf("UpsertOrganizationConfig() error = %v", err)
@@ -29,7 +30,7 @@ func TestUpsertOrganizationConfigCreatesNewConfigWithDefaults(t *testing.T) {
 		t.Fatalf("ErrorColor = %q, want default", cfg.ErrorColor)
 	}
 	org := cfg.Orgs["dev"]
-	if org.URL != "https://dev.awsapps.com/start" || org.Prefix != "dev" || org.Region != "us-east-1" {
+	if org.URL != "https://dev.awsapps.com/start" || org.Prefix != "dev" || org.EffectiveSSORegion() != "us-east-1" {
 		t.Fatalf("org = %#v, want written org values", org)
 	}
 }
@@ -49,10 +50,10 @@ region = "eu-west-1"
 	}
 
 	err = UpsertOrganizationConfig(configPath, Organization{
-		Name:   "dev",
-		URL:    "https://dev.awsapps.com/start",
-		Prefix: "dev",
-		Region: "us-east-1",
+		Name:      "dev",
+		URL:       "https://dev.awsapps.com/start",
+		Prefix:    "dev",
+		SSORegion: "us-east-1",
 	})
 	if err != nil {
 		t.Fatalf("UpsertOrganizationConfig() error = %v", err)
@@ -70,8 +71,8 @@ region = "eu-west-1"
 	if _, ok := cfg.Orgs["existing"]; !ok {
 		t.Fatal("existing org missing after upsert")
 	}
-	if got := cfg.Orgs["dev"].Region; got != "us-east-1" {
-		t.Fatalf("dev region = %q, want %q", got, "us-east-1")
+	if got := cfg.Orgs["dev"].EffectiveSSORegion(); got != "us-east-1" {
+		t.Fatalf("dev sso region = %q, want %q", got, "us-east-1")
 	}
 }
 
@@ -88,10 +89,10 @@ region = "eu-west-1"
 	}
 
 	err = UpsertOrganizationConfig(configPath, Organization{
-		Name:   "dev",
-		URL:    "https://shared.awsapps.com/start",
-		Prefix: "dev",
-		Region: "us-east-1",
+		Name:      "dev",
+		URL:       "https://shared.awsapps.com/start",
+		Prefix:    "dev",
+		SSORegion: "us-east-1",
 	})
 	if err == nil {
 		t.Fatal("UpsertOrganizationConfig() error = nil, want duplicate URL error")
@@ -111,10 +112,10 @@ region = "eu-west-1"
 	}
 
 	err = UpsertOrganizationConfig(configPath, Organization{
-		Name:   "dev",
-		URL:    "https://dev.awsapps.com/start",
-		Prefix: "shared",
-		Region: "us-east-1",
+		Name:      "dev",
+		URL:       "https://dev.awsapps.com/start",
+		Prefix:    "shared",
+		SSORegion: "us-east-1",
 	})
 	if err == nil {
 		t.Fatal("UpsertOrganizationConfig() error = nil, want duplicate prefix error")
@@ -134,10 +135,11 @@ region = "us-west-1"
 	}
 
 	err = UpsertOrganizationConfig(configPath, Organization{
-		Name:   "dev",
-		URL:    "https://new.awsapps.com/start",
-		Prefix: "new",
-		Region: "us-east-1",
+		Name:          "dev",
+		URL:           "https://new.awsapps.com/start",
+		Prefix:        "new",
+		SSORegion:     "us-east-1",
+		DefaultRegion: "us-west-2",
 	})
 	if err != nil {
 		t.Fatalf("UpsertOrganizationConfig() error = %v", err)
@@ -148,7 +150,38 @@ region = "us-west-1"
 		t.Fatalf("Init() error = %v", err)
 	}
 	org := GetInstance().Orgs["dev"]
-	if org.URL != "https://new.awsapps.com/start" || org.Prefix != "new" || org.Region != "us-east-1" {
+	if org.URL != "https://new.awsapps.com/start" || org.Prefix != "new" || org.EffectiveSSORegion() != "us-east-1" || org.EffectiveDefaultRegion() != "us-west-2" {
 		t.Fatalf("org = %#v, want updated org", org)
+	}
+}
+
+func TestUpsertOrganizationConfigWritesExplicitRegionKeys(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "aws-sso-creds.toml")
+
+	err := UpsertOrganizationConfig(configPath, Organization{
+		Name:          "dev",
+		URL:           "https://dev.awsapps.com/start",
+		Prefix:        "dev",
+		SSORegion:     "us-east-1",
+		DefaultRegion: "eu-west-1",
+	})
+	if err != nil {
+		t.Fatalf("UpsertOrganizationConfig() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	text := string(raw)
+	if !strings.Contains(text, `sso_region = "us-east-1"`) {
+		t.Fatalf("config = %q, want sso_region", text)
+	}
+	if !strings.Contains(text, `default_region = "eu-west-1"`) {
+		t.Fatalf("config = %q, want default_region", text)
+	}
+	if strings.Contains(text, "\nregion = ") {
+		t.Fatalf("config = %q, did not want legacy region key", text)
 	}
 }

--- a/internal/app/sso.go
+++ b/internal/app/sso.go
@@ -71,19 +71,21 @@ func loginWithDeps(
 	deps loginDeps,
 ) (*SSOFlow, error) {
 	ctx := context.Background()
+	ssoRegion := org.EffectiveSSORegion()
+	defaultRegion := org.EffectiveDefaultRegion()
 	var oidcClient oidcClientAPI
 	getOIDCClient := func() (oidcClientAPI, error) {
 		if oidcClient != nil {
 			return oidcClient, nil
 		}
-		client, err := deps.newOIDCClient(ctx, org.Region)
+		client, err := deps.newOIDCClient(ctx, ssoRegion)
 		if err != nil {
 			return nil, err
 		}
 		oidcClient = client
 		return oidcClient, nil
 	}
-	clientCredentials, err := deps.getClientCreds(org.Region)
+	clientCredentials, err := deps.getClientCreds(ssoRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -106,12 +108,12 @@ func loginWithDeps(
 			ClientSecret: *resp.ClientSecret,
 			ExpiresAt:    tm.Format(time.RFC3339),
 		}
-		if err := deps.saveClientCreds(clientCredentials, &org.Region); err != nil {
+		if err := deps.saveClientCreds(clientCredentials, &ssoRegion); err != nil {
 			return nil, err
 		}
 	}
 
-	ssoToken, err := deps.getToken(org.URL, org.Region)
+	ssoToken, err := deps.getToken(org.URL, ssoRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +171,7 @@ func loginWithDeps(
 
 			ssoToken = &cache.SSOToken{
 				StartUrl:    org.URL,
-				Region:      org.Region,
+				Region:      ssoRegion,
 				AccessToken: *createTokenOutput.AccessToken,
 				ExpiresAt:   deps.now().Add(time.Second * time.Duration(createTokenOutput.ExpiresIn)).Format(time.RFC3339),
 			}
@@ -195,19 +197,20 @@ func loginWithDeps(
 		return nil, err
 	}
 
-	ssoClient, err := deps.newSSOClient(ctx, org.Region)
+	ssoClient, err := deps.newSSOClient(ctx, ssoRegion)
 	if err != nil {
 		return nil, err
 	}
 
 	return &SSOFlow{
-		accessToken: &ssoToken.AccessToken,
-		ssoClient:   ssoClient,
-		configFile:  file,
-		ssoRegion:   &org.Region,
-		ssoStartUrl: &org.URL,
-		orgName:     org.Name,
-		prefix:      org.Prefix,
+		accessToken:   &ssoToken.AccessToken,
+		ssoClient:     ssoClient,
+		configFile:    file,
+		ssoRegion:     &ssoRegion,
+		defaultRegion: &defaultRegion,
+		ssoStartUrl:   &org.URL,
+		orgName:       org.Name,
+		prefix:        org.Prefix,
 	}, nil
 }
 
@@ -263,7 +266,7 @@ func (s *SSOFlow) getAccountRoles(
 		section.NewKey("sso_account_name", awsv2.ToString(acc.AccountName))
 		section.NewKey("sso_account_id", awsv2.ToString(acc.AccountId))
 		section.NewKey("sso_role_name", awsv2.ToString(role.RoleName))
-		section.NewKey("region", *s.ssoRegion)
+		section.NewKey("region", *s.defaultRegion)
 		section.NewKey("org", s.orgName)
 		section.NewKey("sso_auto_populated", "true")
 	}
@@ -406,7 +409,9 @@ func GetCachedSSOFlow(org appconfig.Organization) (*SSOFlow, error) {
 }
 
 func getCachedSSOFlowWithDeps(org appconfig.Organization, deps loginDeps) (*SSOFlow, error) {
-	clientCredentials, err := deps.getClientCreds(org.Region)
+	ssoRegion := org.EffectiveSSORegion()
+	defaultRegion := org.EffectiveDefaultRegion()
+	clientCredentials, err := deps.getClientCreds(ssoRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -415,7 +420,7 @@ func getCachedSSOFlowWithDeps(org appconfig.Organization, deps loginDeps) (*SSOF
 		return nil, fmt.Errorf("Unable to get client credentials, please login with this CLI and then try again")
 	}
 
-	ssoToken, err := deps.getToken(org.URL, org.Region)
+	ssoToken, err := deps.getToken(org.URL, ssoRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -429,18 +434,19 @@ func getCachedSSOFlowWithDeps(org appconfig.Organization, deps loginDeps) (*SSOF
 		return nil, err
 	}
 
-	ssoClient, err := deps.newSSOClient(context.Background(), org.Region)
+	ssoClient, err := deps.newSSOClient(context.Background(), ssoRegion)
 	if err != nil {
 		return nil, err
 	}
 
 	return &SSOFlow{
-		accessToken: &ssoToken.AccessToken,
-		ssoClient:   ssoClient,
-		configFile:  file,
-		ssoRegion:   &org.Region,
-		ssoStartUrl: &org.URL,
-		orgName:     org.Name,
-		prefix:      org.Prefix,
+		accessToken:   &ssoToken.AccessToken,
+		ssoClient:     ssoClient,
+		configFile:    file,
+		ssoRegion:     &ssoRegion,
+		defaultRegion: &defaultRegion,
+		ssoStartUrl:   &org.URL,
+		orgName:       org.Name,
+		prefix:        org.Prefix,
 	}, nil
 }

--- a/internal/app/sso_test.go
+++ b/internal/app/sso_test.go
@@ -356,6 +356,51 @@ func TestPopulateRolesCreatesConfigSectionsForPagedAccountsAndRoles(t *testing.T
 			t.Fatalf("PopulateRoles()[%d] = %q, want %q", i, got[i], want[i])
 		}
 	}
+
+	section, err := cfgFile.File.GetSection("profile dev:Dev-Account:Admin")
+	if err != nil {
+		t.Fatalf("GetSection() error = %v", err)
+	}
+	if got := section.Key("sso_region").String(); got != "us-east-1" {
+		t.Fatalf("sso_region = %q, want %q", got, "us-east-1")
+	}
+	if got := section.Key("region").String(); got != "us-east-1" {
+		t.Fatalf("region = %q, want %q", got, "us-east-1")
+	}
+}
+
+func TestPopulateRolesUsesDefaultRegionWhenProvided(t *testing.T) {
+	setupAppConfig(t)
+	cfgFile := newAWSFile(t)
+	ssoClient := &fakeSSOClient{
+		listAccountsOutputs: []*sso.ListAccountsOutput{
+			{
+				AccountList: []ssotypes.AccountInfo{{AccountId: awsv2.String("111111111111"), AccountName: awsv2.String("Dev Account")}},
+			},
+		},
+		listAccountRoles: map[string][]*sso.ListAccountRolesOutput{
+			"111111111111": {{RoleList: []ssotypes.RoleInfo{{RoleName: awsv2.String("Admin")}}}},
+		},
+	}
+	flow := newTestFlow(cfgFile, ssoClient)
+	defaultRegion := "eu-west-1"
+	flow.defaultRegion = &defaultRegion
+
+	_, err := flow.PopulateRoles()
+	if err != nil {
+		t.Fatalf("PopulateRoles() error = %v", err)
+	}
+
+	section, err := cfgFile.File.GetSection("profile dev:Dev-Account:Admin")
+	if err != nil {
+		t.Fatalf("GetSection() error = %v", err)
+	}
+	if got := section.Key("sso_region").String(); got != "us-east-1" {
+		t.Fatalf("sso_region = %q, want %q", got, "us-east-1")
+	}
+	if got := section.Key("region").String(); got != "eu-west-1" {
+		t.Fatalf("region = %q, want %q", got, "eu-west-1")
+	}
 }
 
 func TestPopulateRolesReturnsListAccountsError(t *testing.T) {
@@ -557,23 +602,25 @@ func newAWSFile(t *testing.T) *files.AWSFile {
 func newTestFlow(cfgFile *files.AWSFile, client ssoClientAPI) *SSOFlow {
 	token := "token"
 	region := "us-east-1"
+	defaultRegion := "us-east-1"
 	startURL := "https://dev.awsapps.com/start"
 	return &SSOFlow{
-		accessToken: &token,
-		ssoClient:   client,
-		configFile:  cfgFile,
-		ssoRegion:   &region,
-		ssoStartUrl: &startURL,
-		orgName:     "dev",
-		prefix:      "dev",
+		accessToken:   &token,
+		ssoClient:     client,
+		configFile:    cfgFile,
+		ssoRegion:     &region,
+		defaultRegion: &defaultRegion,
+		ssoStartUrl:   &startURL,
+		orgName:       "dev",
+		prefix:        "dev",
 	}
 }
 
 func validOrg() config.Organization {
 	return config.Organization{
-		Name:   "dev",
-		Prefix: "dev",
-		URL:    "https://dev.awsapps.com/start",
-		Region: "us-east-1",
+		Name:      "dev",
+		Prefix:    "dev",
+		URL:       "https://dev.awsapps.com/start",
+		SSORegion: "us-east-1",
 	}
 }

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -17,6 +17,7 @@ type SSOFlow struct {
 	credentialsFile *files.AWSFile
 	ssoClient       ssoClientAPI
 	ssoRegion       *string
+	defaultRegion   *string
 	ssoStartUrl     *string
 	orgName         string
 	prefix          string


### PR DESCRIPTION
## Summary

  - add first-class `sso_region` and optional `default_region` config support
  - keep legacy `region` as a backward-compatible fallback for old configs
  - update `init` and generated AWS profiles so `sso_region` and default AWS `region` are no longer conflated

  ## Changes

  - add effective-region helpers to the organization config model
  - resolve SSO auth/cache/client calls from `sso_region`
  - write generated AWS profiles with:
    - `sso_region = <effective sso region>`
    - `region = <effective default region>`
  - update `init` to prompt for SSO region and optional default AWS region
  - update README config examples and docs
  - add tests for:
    - legacy `region` fallback
    - explicit `sso_region` and `default_region`
    - `init` writing the new keys
    - populated profile region behavior

  ## Backward Compatibility

  Existing configs that only use `region` continue to work.
  For new or updated configs, `init` now writes `sso_region`, and writes `default_region` only when needed.

  ## Verification

  ```bash
  GOCACHE=$PWD/.cache/go-build go test ./...
  ```