### PR TITLE
fix: create ~/.aws before loading config and credentials files

### DIFF
--- a/internal/pkg/files/files.go
+++ b/internal/pkg/files/files.go
@@ -5,14 +5,23 @@ import (
 	"fmt"
 	"os"
 	"path"
+	pathpkg "path/filepath"
 
 	"gopkg.in/ini.v1"
 )
 
 func NewConfigFile(homedir string) (*AWSFile, error) {
 	path := path.Join(homedir, ".aws", "config")
-	f, err := os.OpenFile(path, os.O_CREATE, 0644)
-	f.Close()
+	if err := os.MkdirAll(pathpkg.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	if err := f.Close(); err != nil {
+		return nil, err
+	}
 	file, err := ini.Load(path)
 	if err != nil {
 		return nil, err
@@ -56,18 +65,26 @@ func IsValidEntry(s *ini.Section, organization string) bool {
 	return false
 }
 
-func(f *AWSFile) GetentryByAWSProfile(profile string) (*ini.Section, error) {
-  section, err := f.File.GetSection(fmt.Sprintf("profile %s", profile))
-  if err != nil {
-    return nil, err
-  }
-  return section, nil
+func (f *AWSFile) GetentryByAWSProfile(profile string) (*ini.Section, error) {
+	section, err := f.File.GetSection(fmt.Sprintf("profile %s", profile))
+	if err != nil {
+		return nil, err
+	}
+	return section, nil
 }
 
 func NewCredentialsFile(homedir string) (*AWSFile, error) {
 	path := path.Join(homedir, ".aws", "credentials")
-	f, err := os.OpenFile(path, os.O_CREATE, 0644)
-	f.Close()
+	if err := os.MkdirAll(pathpkg.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	if err := f.Close(); err != nil {
+		return nil, err
+	}
 	file, err := ini.Load(path)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/files/files_test.go
+++ b/internal/pkg/files/files_test.go
@@ -85,3 +85,33 @@ func TestNewCredentialsFileCreatesCredentialsPath(t *testing.T) {
 		t.Fatalf("credentials file stat error = %v", err)
 	}
 }
+
+func TestNewConfigFileCreatesAWSDirectoryWhenMissing(t *testing.T) {
+	home := t.TempDir()
+
+	configFile, err := NewConfigFile(home)
+	if err != nil {
+		t.Fatalf("NewConfigFile() error = %v", err)
+	}
+	if configFile.Path != filepath.Join(home, ".aws", "config") {
+		t.Fatalf("Path = %q, want %q", configFile.Path, filepath.Join(home, ".aws", "config"))
+	}
+	if _, err := os.Stat(configFile.Path); err != nil {
+		t.Fatalf("config file stat error = %v", err)
+	}
+}
+
+func TestNewCredentialsFileCreatesAWSDirectoryWhenMissing(t *testing.T) {
+	home := t.TempDir()
+
+	credentialsFile, err := NewCredentialsFile(home)
+	if err != nil {
+		t.Fatalf("NewCredentialsFile() error = %v", err)
+	}
+	if credentialsFile.Path != filepath.Join(home, ".aws", "credentials") {
+		t.Fatalf("Path = %q, want %q", credentialsFile.Path, filepath.Join(home, ".aws", "credentials"))
+	}
+	if _, err := os.Stat(credentialsFile.Path); err != nil {
+		t.Fatalf("credentials file stat error = %v", err)
+	}
+}

--- a/internal/pkg/files/files_test.go
+++ b/internal/pkg/files/files_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gopkg.in/ini.v1"
 )
 
 func TestConfigAndCredentialsHelpersManageAutoPopulatedEntries(t *testing.T) {
@@ -113,5 +115,107 @@ func TestNewCredentialsFileCreatesAWSDirectoryWhenMissing(t *testing.T) {
 	}
 	if _, err := os.Stat(credentialsFile.Path); err != nil {
 		t.Fatalf("credentials file stat error = %v", err)
+	}
+}
+
+func TestConfigFileSSOEmptyReturnsTrueForInvalidConfig(t *testing.T) {
+	home := t.TempDir()
+	awsDir := filepath.Join(home, ".aws")
+	if err := os.MkdirAll(awsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	configPath := filepath.Join(awsDir, "config")
+	if err := os.WriteFile(configPath, []byte("[profile broken\norg=dev\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if !ConfigFileSSOEmpty(home, "dev") {
+		t.Fatal("ConfigFileSSOEmpty() = false, want true for invalid config")
+	}
+}
+
+func TestIsValidEntryRequiresOrganizationAndAutoPopulatedKey(t *testing.T) {
+	file := ini.Empty()
+	withOrg, err := file.NewSection("profile dev")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = withOrg.NewKey("org", "dev")
+	_, _ = withOrg.NewKey("sso_auto_populated", "true")
+	if !IsValidEntry(withOrg, "dev") {
+		t.Fatal("IsValidEntry() = false, want true")
+	}
+	if IsValidEntry(withOrg, "prod") {
+		t.Fatal("IsValidEntry() = true, want false for mismatched org")
+	}
+
+	missingAuto, err := file.NewSection("profile no-auto")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = missingAuto.NewKey("org", "dev")
+	if IsValidEntry(missingAuto, "dev") {
+		t.Fatal("IsValidEntry() = true, want false without sso_auto_populated")
+	}
+
+	missingOrg, err := file.NewSection("profile no-org")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = missingOrg.NewKey("sso_auto_populated", "true")
+	if IsValidEntry(missingOrg, "dev") {
+		t.Fatal("IsValidEntry() = true, want false without org")
+	}
+}
+
+func TestGetentryByAWSProfileReturnsErrorForMissingSection(t *testing.T) {
+	home := t.TempDir()
+	configFile, err := NewConfigFile(home)
+	if err != nil {
+		t.Fatalf("NewConfigFile() error = %v", err)
+	}
+
+	if _, err := configFile.GetentryByAWSProfile("missing"); err == nil {
+		t.Fatal("GetentryByAWSProfile() error = nil, want error")
+	}
+}
+
+func TestCleanTemporaryRolesRemovesOnlyMatchingOrganization(t *testing.T) {
+	home := t.TempDir()
+	configFile, err := NewConfigFile(home)
+	if err != nil {
+		t.Fatalf("NewConfigFile() error = %v", err)
+	}
+
+	keepOtherOrg, err := configFile.File.NewSection("profile keep-other-org")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = keepOtherOrg.NewKey("org", "prod")
+	_, _ = keepOtherOrg.NewKey("sso_auto_populated", "true")
+
+	keepManual, err := configFile.File.NewSection("profile keep-manual")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = keepManual.NewKey("org", "dev")
+
+	removeMatch, err := configFile.File.NewSection("profile remove-match")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = removeMatch.NewKey("org", "dev")
+	_, _ = removeMatch.NewKey("sso_auto_populated", "true")
+
+	configFile.CleanTemporaryRoles("dev")
+
+	if _, err := configFile.File.GetSection("profile remove-match"); err == nil {
+		t.Fatal("matched auto-populated section was not removed")
+	}
+	if _, err := configFile.File.GetSection("profile keep-other-org"); err != nil {
+		t.Fatal("non-matching org section was removed")
+	}
+	if _, err := configFile.File.GetSection("profile keep-manual"); err != nil {
+		t.Fatal("manual section was removed")
 	}
 }

--- a/internal/pkg/ui/ui.go
+++ b/internal/pkg/ui/ui.go
@@ -5,6 +5,7 @@ import (
 	"os/user"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	sso "github.com/JorgeReus/aws-sso-creds/internal/app"
@@ -35,25 +36,29 @@ type programRunner interface {
 }
 
 type uiDeps struct {
-	currentUser          func() (*user.User, error)
+	currentUser           func() (*user.User, error)
 	validateSuperuserFile func(string, *user.User) string
-	newProgram           func(tea.Model) programRunner
-	login                func(config.Organization, bool, bool, *bus.Bus) (flowAPI, error)
-	configFileSSOEmpty   func(string, string) bool
-	println              func(...interface{}) (int, error)
-	sleep                func(time.Duration)
+	newProgram            func(tea.Model) programRunner
+	login                 func(config.Organization, bool, bool, *bus.Bus) (flowAPI, error)
+	configFileSSOEmpty    func(string, string) bool
+	println               func(...interface{}) (int, error)
+	sleep                 func(time.Duration)
+	startSubscriber       func(uiDeps)
+	startFlow             func(UI, uiDeps)
 }
 
 var (
-	c                 config.Config
-	errorColor        te.Color
-	informationColor  te.Color
-	warningColor      te.Color
-	focusColor        te.Color
-	spinnerColor      te.Color
-	flow              flowAPI
-	hasFinished       bool
-	needsUserApproval = false
+	c                config.Config
+	errorColor       te.Color
+	informationColor te.Color
+	warningColor     te.Color
+	focusColor       te.Color
+	spinnerColor     te.Color
+	flow             flowAPI
+	hasFinished      atomic.Bool
+
+	needsUserApproval atomic.Bool
+	displayMsgMu      sync.RWMutex
 	displayMsg        string
 	outputLines       []string
 	outputLinesMu     sync.RWMutex
@@ -64,8 +69,8 @@ var (
 var uiDepsFactory = defaultUIDeps
 
 func defaultUIDeps() uiDeps {
-	return uiDeps{
-		currentUser: user.Current,
+	deps := uiDeps{
+		currentUser:           user.Current,
 		validateSuperuserFile: util.ValidateSuperuserFile,
 		newProgram: func(m tea.Model) programRunner {
 			return tea.NewProgram(m)
@@ -77,15 +82,32 @@ func defaultUIDeps() uiDeps {
 		println:            fmt.Println,
 		sleep:              time.Sleep,
 	}
+	deps.startSubscriber = channelSubscriberWithDeps
+	deps.startFlow = handleFlowWithDeps
+	return deps
 }
 
 func resetUIStateForTest() {
-	hasFinished = false
-	needsUserApproval = false
-	displayMsg = ""
+	hasFinished.Store(false)
+	needsUserApproval.Store(false)
+	setDisplayMsg("")
+	outputLinesMu.Lock()
 	outputLines = nil
+	outputLinesMu.Unlock()
 	msgBus = bus.NewBus()
 	flow = nil
+}
+
+func setDisplayMsg(msg string) {
+	displayMsgMu.Lock()
+	defer displayMsgMu.Unlock()
+	displayMsg = msg
+}
+
+func getDisplayMsg() string {
+	displayMsgMu.RLock()
+	defer displayMsgMu.RUnlock()
+	return displayMsg
 }
 
 func appendOutputLine(line string) {
@@ -150,7 +172,9 @@ func startWithDeps(u UI, deps uiDeps) error {
 
 	m := initialModel()
 	p := deps.newProgram(m)
-	go handleFlowWithDeps(u, deps)
+	if deps.startFlow != nil {
+		go deps.startFlow(u, deps)
+	}
 	if err := p.Start(); err != nil {
 		_, _ = deps.println(fmt.Sprintf("Error starting program: %s", err))
 		return err
@@ -159,15 +183,16 @@ func startWithDeps(u UI, deps uiDeps) error {
 }
 
 func (m model) View() string {
-	if hasFinished {
+	if hasFinished.Load() {
 		return renderedOutputLines()
 	}
 
 	output := renderedOutputLines()
+	msg := getDisplayMsg()
 	if output == "" {
-		return te.String(m.spinner.View()).Foreground(spinnerColor).String() + displayMsg
+		return te.String(m.spinner.View()).Foreground(spinnerColor).String() + msg
 	}
-	return te.String(m.spinner.View()).Foreground(spinnerColor).String() + displayMsg + "\n" + output
+	return te.String(m.spinner.View()).Foreground(spinnerColor).String() + msg + "\n" + output
 }
 
 func (m model) Init() tea.Cmd {
@@ -183,7 +208,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "q":
 			return m, tea.Quit
 		case "enter":
-			if needsUserApproval {
+			if needsUserApproval.Load() {
 				msgBus.Send(bus.BusMsg{MsgType: bus.MSG_TYPE_CONT, Contents: ""})
 			}
 			return m, nil
@@ -192,7 +217,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case spinner.TickMsg:
 		m.spinner, cmd = m.spinner.Update(msg)
-		if hasFinished {
+		if hasFinished.Load() {
 			return m, tea.Quit
 		}
 		return m, cmd
@@ -207,8 +232,8 @@ func handleBusMessage(msg bus.BusMsg, deps uiDeps) {
 		appendOutputLine(te.String(msg.Contents).Foreground(informationColor).String())
 	case bus.MSG_TYPE_ERR:
 		appendOutputLine(printWarning(msg.Contents))
-		displayMsg = te.String("Continue in your browser and press ENTER").Foreground(informationColor).String()
-		needsUserApproval = true
+		setDisplayMsg(te.String("Continue in your browser and press ENTER").Foreground(informationColor).String())
+		needsUserApproval.Store(true)
 	default:
 	}
 }
@@ -230,29 +255,31 @@ func (u *UI) handleFlow() {
 }
 
 func handleFlowWithDeps(u UI, deps uiDeps) {
-	displayMsg = te.String(fmt.Sprintf("Logging in into AWS SSO org: %s", u.Org.Name)).
+	setDisplayMsg(te.String(fmt.Sprintf("Logging in into AWS SSO org: %s", u.Org.Name)).
 		Foreground(informationColor).
-		String()
+		String())
 
-	go channelSubscriberWithDeps(deps)
+	if deps.startSubscriber != nil {
+		go deps.startSubscriber(deps)
+	}
 
 	var err error
 	flow, err = deps.login(u.Org, u.ForceLogin, u.NoBrowser, msgBus)
 	if err != nil {
 		appendOutputLine(printErr(err))
-		hasFinished = true
+		hasFinished.Store(true)
 		return
 	}
 
 	isNewRun := deps.configFileSSOEmpty(config.GetInstance().Home, u.Org.Name)
 
 	if u.PopulateRoles || isNewRun {
-		displayMsg = "Updating roles"
+		setDisplayMsg("Updating roles")
 		appendOutputLine("Synced roles in ~/.aws/config")
 		roles, err := flow.PopulateRoles()
 		if err != nil {
 			appendOutputLine(printErr(err))
-			hasFinished = true
+			hasFinished.Store(true)
 			return
 		}
 		for _, role := range roles {
@@ -264,14 +291,14 @@ func handleFlowWithDeps(u UI, deps uiDeps) {
 	}
 
 	if u.CreateStatic {
-		displayMsg = te.String("Getting static credentials").Foreground(informationColor).String()
+		setDisplayMsg(te.String("Getting static credentials").Foreground(informationColor).String())
 		roles, err := flow.GetCredentials()
 		if err != nil {
 			appendOutputLine(printErr(err))
-			hasFinished = true
+			hasFinished.Store(true)
 			return
 		}
-		displayMsg = "Updating static credentials"
+		setDisplayMsg("Updating static credentials")
 		appendOutputLine("Added temporary credentials in ~/.aws/credentials")
 		for _, role := range roles {
 			if role.WasSuccesful {
@@ -293,5 +320,5 @@ func handleFlowWithDeps(u UI, deps uiDeps) {
 	if (u.PopulateRoles && u.CreateStatic) || isNewRun {
 		appendOutputLine("You can use aws-sso-creds -l to select your profile")
 	}
-	hasFinished = true
+	hasFinished.Store(true)
 }

--- a/internal/pkg/ui/ui_test.go
+++ b/internal/pkg/ui/ui_test.go
@@ -57,6 +57,8 @@ func TestStartWithDepsInitializesAndRunsProgram(t *testing.T) {
 		configFileSSOEmpty: func(string, string) bool { return false },
 		println:            func(...interface{}) (int, error) { return 0, nil },
 		sleep:              func(time.Duration) {},
+		startSubscriber:    func(uiDeps) {},
+		startFlow:          func(UI, uiDeps) {},
 	})
 	if err != nil {
 		t.Fatalf("startWithDeps() error = %v", err)
@@ -73,7 +75,7 @@ func TestModelViewIncludesDisplayMessage(t *testing.T) {
 	resetUIStateForTest()
 	setupUIConfig(t)
 
-	displayMsg = "continue"
+	setDisplayMsg("continue")
 	view := initialModel().View()
 	if !strings.Contains(view, "continue") {
 		t.Fatalf("View() = %q, want display message", view)
@@ -103,6 +105,8 @@ func TestStartWithDepsReturnsCurrentUserError(t *testing.T) {
 		configFileSSOEmpty:    func(string, string) bool { return false },
 		println:               func(...interface{}) (int, error) { return 0, nil },
 		sleep:                 func(time.Duration) {},
+		startSubscriber:       func(uiDeps) {},
+		startFlow:             func(UI, uiDeps) {},
 	})
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("startWithDeps() error = %v, want %v", err, wantErr)
@@ -111,7 +115,7 @@ func TestStartWithDepsReturnsCurrentUserError(t *testing.T) {
 
 func TestModelUpdateSendsContinueMessageOnEnterWhenApprovalNeeded(t *testing.T) {
 	resetUIStateForTest()
-	needsUserApproval = true
+	needsUserApproval.Store(true)
 	msgBus = &bus.Bus{Channel: make(chan bus.BusMsg, 1)}
 
 	m := initialModel()
@@ -137,7 +141,7 @@ func TestModelUpdateQuitsOnCtrlC(t *testing.T) {
 
 func TestModelUpdateQuitsOnFinishedSpinnerTick(t *testing.T) {
 	resetUIStateForTest()
-	hasFinished = true
+	hasFinished.Store(true)
 
 	_, cmd := initialModel().Update(spinner.TickMsg{})
 	if cmd == nil {
@@ -174,9 +178,9 @@ func TestHandleBusMessageSetsApprovalState(t *testing.T) {
 
 	handleBusMessage(bus.BusMsg{MsgType: bus.MSG_TYPE_ERR, Contents: "open browser"}, uiDeps{
 		println: func(...interface{}) (int, error) { return 0, nil },
-		sleep: func(time.Duration) {},
+		sleep:   func(time.Duration) {},
 	})
-	if !needsUserApproval {
+	if !needsUserApproval.Load() {
 		t.Fatal("needsUserApproval = false, want true")
 	}
 	if !strings.Contains(renderedOutputLines(), "Warning: open browser") {
@@ -214,7 +218,7 @@ func TestHandleFlowWithDepsPopulatesRolesAndCredentials(t *testing.T) {
 		},
 		sleep: func(time.Duration) {},
 	})
-	if !hasFinished {
+	if !hasFinished.Load() {
 		t.Fatal("hasFinished = false, want true")
 	}
 	if printCalls != 0 {
@@ -242,7 +246,7 @@ func TestHandleFlowWithDepsPrintsLoginError(t *testing.T) {
 		},
 		configFileSSOEmpty: func(string, string) bool { return false },
 		println:            func(...interface{}) (int, error) { return 0, nil },
-		sleep: func(time.Duration) {},
+		sleep:              func(time.Duration) {},
 	})
 	if !strings.Contains(renderedOutputLines(), "Error: boom") {
 		t.Fatalf("renderedOutputLines() = %q, want login error", renderedOutputLines())
@@ -265,6 +269,8 @@ func TestStartWrapperUsesFactoryDeps(t *testing.T) {
 			configFileSSOEmpty:    func(string, string) bool { return false },
 			println:               func(...interface{}) (int, error) { return 0, nil },
 			sleep:                 func(time.Duration) {},
+			startSubscriber:       func(uiDeps) {},
+			startFlow:             func(UI, uiDeps) {},
 		}
 	}
 
@@ -291,11 +297,13 @@ func TestHandleFlowWrapperUsesFactoryDeps(t *testing.T) {
 			configFileSSOEmpty:    func(string, string) bool { return false },
 			println:               func(...interface{}) (int, error) { return 0, nil },
 			sleep:                 func(time.Duration) {},
+			startSubscriber:       func(uiDeps) {},
+			startFlow:             func(UI, uiDeps) { hasFinished.Store(true) },
 		}
 	}
 
 	(&UI{Org: config.Organization{Name: "dev"}}).handleFlow()
-	if !hasFinished {
+	if !hasFinished.Load() {
 		t.Fatal("hasFinished = false, want true")
 	}
 }

--- a/internal/pkg/ui/ui_test.go
+++ b/internal/pkg/ui/ui_test.go
@@ -82,6 +82,18 @@ func TestModelViewIncludesDisplayMessage(t *testing.T) {
 	}
 }
 
+func TestModelViewIncludesOutputLinesWhenPresent(t *testing.T) {
+	resetUIStateForTest()
+	setupUIConfig(t)
+
+	setDisplayMsg("continue")
+	appendOutputLine("line one")
+	view := initialModel().View()
+	if !strings.Contains(view, "continue") || !strings.Contains(view, "line one") {
+		t.Fatalf("View() = %q, want display message and output line", view)
+	}
+}
+
 func TestModelInitReturnsSpinnerTick(t *testing.T) {
 	cmd := initialModel().Init()
 	if cmd == nil {
@@ -186,6 +198,9 @@ func TestHandleBusMessageSetsApprovalState(t *testing.T) {
 	if !strings.Contains(renderedOutputLines(), "Warning: open browser") {
 		t.Fatalf("renderedOutputLines() = %q, want warning message", renderedOutputLines())
 	}
+	if !strings.Contains(getDisplayMsg(), "Continue in your browser and press ENTER") {
+		t.Fatalf("displayMsg = %q, want approval prompt", getDisplayMsg())
+	}
 }
 
 func TestHandleFlowWithDepsPopulatesRolesAndCredentials(t *testing.T) {
@@ -250,6 +265,69 @@ func TestHandleFlowWithDepsPrintsLoginError(t *testing.T) {
 	})
 	if !strings.Contains(renderedOutputLines(), "Error: boom") {
 		t.Fatalf("renderedOutputLines() = %q, want login error", renderedOutputLines())
+	}
+}
+
+func TestHandleFlowWithDepsPrintsPopulateRolesError(t *testing.T) {
+	resetUIStateForTest()
+	setupUIConfig(t)
+
+	handleFlowWithDeps(UI{PopulateRoles: true, Org: config.Organization{Name: "dev"}}, uiDeps{
+		currentUser:           func() (*user.User, error) { return &user.User{Uid: "1000"}, nil },
+		validateSuperuserFile: func(string, *user.User) string { return "" },
+		newProgram:            func(tea.Model) programRunner { return &fakeProgram{} },
+		login: func(config.Organization, bool, bool, *bus.Bus) (flowAPI, error) {
+			return fakeFlow{populateRolesErr: errors.New("populate failed")}, nil
+		},
+		configFileSSOEmpty: func(string, string) bool { return false },
+		println:            func(...interface{}) (int, error) { return 0, nil },
+		sleep:              func(time.Duration) {},
+	})
+	if !strings.Contains(renderedOutputLines(), "Error: populate failed") {
+		t.Fatalf("renderedOutputLines() = %q, want populate error", renderedOutputLines())
+	}
+}
+
+func TestHandleFlowWithDepsPrintsCredentialsError(t *testing.T) {
+	resetUIStateForTest()
+	setupUIConfig(t)
+
+	handleFlowWithDeps(UI{CreateStatic: true, Org: config.Organization{Name: "dev"}}, uiDeps{
+		currentUser:           func() (*user.User, error) { return &user.User{Uid: "1000"}, nil },
+		validateSuperuserFile: func(string, *user.User) string { return "" },
+		newProgram:            func(tea.Model) programRunner { return &fakeProgram{} },
+		login: func(config.Organization, bool, bool, *bus.Bus) (flowAPI, error) {
+			return fakeFlow{credentialsErr: errors.New("credentials failed")}, nil
+		},
+		configFileSSOEmpty: func(string, string) bool { return false },
+		println:            func(...interface{}) (int, error) { return 0, nil },
+		sleep:              func(time.Duration) {},
+	})
+	if !strings.Contains(renderedOutputLines(), "Error: credentials failed") {
+		t.Fatalf("renderedOutputLines() = %q, want credentials error", renderedOutputLines())
+	}
+}
+
+func TestHandleFlowWithDepsPrintsManualRoleEntryError(t *testing.T) {
+	resetUIStateForTest()
+	setupUIConfig(t)
+
+	handleFlowWithDeps(UI{CreateStatic: true, Org: config.Organization{Name: "dev"}}, uiDeps{
+		currentUser:           func() (*user.User, error) { return &user.User{Uid: "1000"}, nil },
+		validateSuperuserFile: func(string, *user.User) string { return "" },
+		newProgram:            func(tea.Model) programRunner { return &fakeProgram{} },
+		login: func(config.Organization, bool, bool, *bus.Bus) (flowAPI, error) {
+			return fakeFlow{credentialsResult: []sso.CredentialsResult{{
+				ProfileName:  "tmp:dev:Broken",
+				WasSuccesful: false,
+			}}}, nil
+		},
+		configFileSSOEmpty: func(string, string) bool { return false },
+		println:            func(...interface{}) (int, error) { return 0, nil },
+		sleep:              func(time.Duration) {},
+	})
+	if !strings.Contains(renderedOutputLines(), "Entry error tmp:dev:Broken in ~/.aws/config") {
+		t.Fatalf("renderedOutputLines() = %q, want entry error", renderedOutputLines())
 	}
 }
 


### PR DESCRIPTION
## Summary
- create the ~/.aws parent directory before loading config or credentials files
- return the actual open/close error instead of risking a nil Close panic
- add regression coverage for homes that do not already contain ~/.aws

## Reproduction
Calling `files.NewConfigFile(home)` or `files.NewCredentialsFile(home)` with a fresh home directory currently fails before `ini.Load` because `os.OpenFile` cannot create nested paths on its own, and the code then calls `f.Close()` even when `f` is nil.

## Testing
- `GOSUMDB=sum.golang.org GOTOOLCHAIN=auto go test ./internal/pkg/files -count=1`
- `GOSUMDB=sum.golang.org GOTOOLCHAIN=auto go test ./internal/app ./internal/app/config ./cmd/aws-sso-creds -count=1`