### PR TITLE
Feat/clean cmd

### DIFF
--- a/cmd/aws-sso-creds/clean.go
+++ b/cmd/aws-sso-creds/clean.go
@@ -1,0 +1,139 @@
+package awsssocreds
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/JorgeReus/aws-sso-creds/internal/app/config"
+	"github.com/JorgeReus/aws-sso-creds/internal/pkg/files"
+	"github.com/spf13/cobra"
+)
+
+type cleanDeps struct {
+	initConfig         func(home, configPath string) error
+	newConfigFile      func(string) (*files.AWSFile, error)
+	newCredentialsFile func(string) (*files.AWSFile, error)
+	nowUnix            func() int64
+}
+
+var cleanDepsFactory = defaultCleanDeps
+
+func defaultCleanDeps() cleanDeps {
+	return cleanDeps{
+		initConfig:         config.Init,
+		newConfigFile:      files.NewConfigFile,
+		newCredentialsFile: files.NewCredentialsFile,
+		nowUnix: func() int64 {
+			return time.Now().Unix()
+		},
+	}
+}
+
+func newCleanCmd(deps cleanDeps) *cobra.Command {
+	var cleanConfig bool
+	var cleanCreds bool
+	var expiredOnly bool
+	determineScopes := func(cmd *cobra.Command) (bool, bool) {
+		configChanged := cmd.Flags().Changed("config-only")
+		credsChanged := cmd.Flags().Changed("creds")
+
+		configScope := cleanConfig
+		credsScope := cleanCreds
+
+		if !configChanged && !credsChanged {
+			credsScope = true
+			if expiredOnly {
+				configScope = false
+			} else {
+				configScope = true
+			}
+		}
+		if expiredOnly {
+			if !credsChanged {
+				credsScope = true
+			}
+			if !configChanged {
+				configScope = false
+			}
+		}
+
+		return configScope, credsScope
+	}
+
+	cmd := &cobra.Command{
+		Use:   "clean [org]",
+		Short: "Remove auto-populated AWS SSO config and credential entries",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := deps.initConfig(home, configPath); err != nil {
+				return err
+			}
+			if err := cobra.MaximumNArgs(1)(cmd, args); err != nil {
+				return err
+			}
+
+			if expiredOnly && cmd.Flags().Changed("config-only") && !cmd.Flags().Changed("creds") {
+				return fmt.Errorf("--expired requires credentials cleanup")
+			}
+
+			if len(args) == 1 {
+				if _, ok := config.GetInstance().Orgs[args[0]]; !ok {
+					return fmt.Errorf(
+						"Organization '%s' not found in config file %s",
+						args[0],
+						configPath,
+					)
+				}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org := ""
+			if len(args) == 1 {
+				org = args[0]
+			}
+
+			effectiveCleanConfig, effectiveCleanCreds := determineScopes(cmd)
+
+			if effectiveCleanConfig {
+				cfg, err := deps.newConfigFile(config.GetInstance().Home)
+				if err != nil {
+					return err
+				}
+				cfg.CleanTemporaryRoles(org)
+				if err := cfg.Save(); err != nil {
+					return err
+				}
+			}
+
+			if effectiveCleanCreds {
+				creds, err := deps.newCredentialsFile(config.GetInstance().Home)
+				if err != nil {
+					return err
+				}
+				if expiredOnly {
+					creds.CleanExpiredCredentials(org, deps.nowUnix())
+				} else {
+					creds.CleanTemporaryRoles(org)
+				}
+				if err := creds.Save(); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().BoolVar(&cleanConfig, "config-only", false, "Clean ~/.aws/config")
+	cmd.Flags().BoolVar(&cleanCreds, "creds", false, "Clean ~/.aws/credentials")
+	cmd.Flags().BoolVarP(&expiredOnly, "expired", "e", false, "Only clean expired credentials")
+
+	return cmd
+}
+
+var cleanCmd = newCleanCmd(cleanDepsFactory())
+
+func init() {
+	rootCmd.AddCommand(cleanCmd)
+}

--- a/cmd/aws-sso-creds/clean_test.go
+++ b/cmd/aws-sso-creds/clean_test.go
@@ -69,7 +69,6 @@ func TestCleanCommandDefaultsToCleaningConfigAndCredentials(t *testing.T) {
 	defer func() { home = origHome }()
 	home = testHome
 	setupCleanConfig(t, testHome)
-	createCleanFixtureFiles(t, testHome)
 
 	cmd := newCleanCmd(cleanDeps{
 		initConfig: func(home, path string) error {
@@ -96,6 +95,7 @@ func TestCleanCommandAllowsExpiredWithConfigAndCredsScopes(t *testing.T) {
 	defer func() { home = origHome }()
 	home = testHome
 	setupCleanConfig(t, testHome)
+	createCleanFixtureFiles(t, testHome)
 	origConfigPath := configPath
 	defer func() {
 		configPath = origConfigPath

--- a/cmd/aws-sso-creds/clean_test.go
+++ b/cmd/aws-sso-creds/clean_test.go
@@ -1,0 +1,291 @@
+package awsssocreds
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/JorgeReus/aws-sso-creds/internal/app/config"
+	"github.com/JorgeReus/aws-sso-creds/internal/pkg/files"
+	"gopkg.in/ini.v1"
+)
+
+func TestCleanCommandRejectsExpiredWithoutCredentialsScope(t *testing.T) {
+	origHome := home
+	defer func() { home = origHome }()
+	testHome := t.TempDir()
+	home = testHome
+
+	cmd := newCleanCmd(cleanDeps{
+		initConfig: func(home, path string) error {
+			setupCleanConfig(t, home)
+			return nil
+		},
+		nowUnix: func() int64 { return 200 },
+	})
+	cmd.SetArgs([]string{"--config-only", "--expired"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "requires credentials cleanup") {
+		t.Fatalf("Execute() error = %v, want invalid scope error", err)
+	}
+}
+
+func TestCleanCommandReturnsOrgNotFoundError(t *testing.T) {
+	testHome := t.TempDir()
+	origHome := home
+	defer func() { home = origHome }()
+	home = testHome
+	origConfigPath := configPath
+	defer func() {
+		configPath = origConfigPath
+	}()
+	configPath = filepath.Join(testHome, "aws-sso-creds.toml")
+
+	cmd := newCleanCmd(cleanDeps{
+		initConfig: func(home, path string) error {
+			config.ResetForTest()
+			config.SetInstanceForTest(&config.Config{
+				Home: home,
+				Orgs: map[string]config.Organization{
+					"dev": {Name: "dev"},
+				},
+			})
+			return nil
+		},
+		nowUnix: func() int64 { return 200 },
+	})
+	cmd.SetArgs([]string{"missing"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "Organization 'missing' not found") {
+		t.Fatalf("Execute() error = %v, want org not found", err)
+	}
+}
+
+func TestCleanCommandDefaultsToCleaningConfigAndCredentials(t *testing.T) {
+	testHome := t.TempDir()
+	origHome := home
+	defer func() { home = origHome }()
+	home = testHome
+	setupCleanConfig(t, testHome)
+	createCleanFixtureFiles(t, testHome)
+
+	cmd := newCleanCmd(cleanDeps{
+		initConfig: func(home, path string) error {
+			setupCleanConfig(t, home)
+			return nil
+		},
+		newConfigFile:      files.NewConfigFile,
+		newCredentialsFile: files.NewCredentialsFile,
+		nowUnix:            func() int64 { return 200 },
+	})
+	cmd.SetArgs([]string{"dev"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	assertSectionMissing(t, filepath.Join(testHome, ".aws", "config"), "profile dev:auto")
+	assertSectionMissing(t, filepath.Join(testHome, ".aws", "credentials"), "tmp:dev:auto")
+}
+
+func TestCleanCommandAllowsExpiredWithConfigAndCredsScopes(t *testing.T) {
+	testHome := t.TempDir()
+	origHome := home
+	defer func() { home = origHome }()
+	home = testHome
+	setupCleanConfig(t, testHome)
+	origConfigPath := configPath
+	defer func() {
+		configPath = origConfigPath
+	}()
+	configPath = filepath.Join(testHome, "aws-sso-creds.toml")
+
+	cmd := newCleanCmd(cleanDeps{
+		initConfig: func(home, path string) error {
+			setupCleanConfig(t, home)
+			return nil
+		},
+		newConfigFile:      files.NewConfigFile,
+		newCredentialsFile: files.NewCredentialsFile,
+		nowUnix:            func() int64 { return 200 },
+	})
+	cmd.SetArgs([]string{"--config-only", "--creds", "--expired"})
+
+	logCredentialSections(t, filepath.Join(testHome, ".aws", "credentials"), "before clean")
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	logCredentialSections(t, filepath.Join(testHome, ".aws", "credentials"), "after clean")
+	assertSectionMissing(t, filepath.Join(testHome, ".aws", "config"), "profile dev:auto")
+	assertSectionMissing(t, filepath.Join(testHome, ".aws", "credentials"), "tmp:dev:expired")
+	assertSectionPresent(t, filepath.Join(testHome, ".aws", "credentials"), "tmp:dev:active")
+}
+
+func TestCleanCommandExpiredOnlyLeavesConfigUntouchedWhenConfigNotRequested(t *testing.T) {
+	testHome := t.TempDir()
+	origHome := home
+	defer func() { home = origHome }()
+	home = testHome
+	setupCleanConfig(t, testHome)
+	createCleanFixtureFiles(t, testHome)
+
+	cmd := newCleanCmd(cleanDeps{
+		initConfig: func(home, path string) error {
+			setupCleanConfig(t, home)
+			return nil
+		},
+		newConfigFile:      files.NewConfigFile,
+		newCredentialsFile: files.NewCredentialsFile,
+		nowUnix:            func() int64 { return 200 },
+	})
+	cmd.SetArgs([]string{"dev", "--expired"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	assertSectionPresent(t, filepath.Join(testHome, ".aws", "config"), "profile dev:auto")
+	assertSectionMissing(t, filepath.Join(testHome, ".aws", "credentials"), "tmp:dev:expired")
+	assertSectionPresent(t, filepath.Join(testHome, ".aws", "credentials"), "tmp:dev:active")
+}
+
+func TestCleanCommandExpiredOnlyAcrossAllOrganizations(t *testing.T) {
+	testHome := t.TempDir()
+	origHome := home
+	defer func() { home = origHome }()
+	home = testHome
+	setupCleanConfig(t, testHome)
+	createCleanFixtureFiles(t, testHome)
+	createCrossOrgCredentialsFixture(t, testHome)
+
+	cmd := newCleanCmd(cleanDeps{
+		initConfig: func(home, path string) error {
+			setupCleanConfig(t, home)
+			return nil
+		},
+		newConfigFile:      files.NewConfigFile,
+		newCredentialsFile: files.NewCredentialsFile,
+		nowUnix:            func() int64 { return 200 },
+	})
+	cmd.SetArgs([]string{"--expired"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	assertSectionPresent(t, filepath.Join(testHome, ".aws", "config"), "profile dev:auto")
+	assertSectionMissing(t, filepath.Join(testHome, ".aws", "credentials"), "tmp:dev:expired")
+	assertSectionMissing(t, filepath.Join(testHome, ".aws", "credentials"), "tmp:prod:expired")
+	assertSectionPresent(t, filepath.Join(testHome, ".aws", "credentials"), "tmp:prod:active")
+}
+
+func setupCleanConfig(t *testing.T, home string) {
+	t.Helper()
+	config.ResetForTest()
+	config.SetInstanceForTest(&config.Config{
+		Home: home,
+		Orgs: map[string]config.Organization{
+			"dev": {
+				Name:   "dev",
+				Prefix: "dev",
+				URL:    "https://dev.awsapps.com/start",
+				Region: "us-east-1",
+			},
+		},
+	})
+}
+
+func createCleanFixtureFiles(t *testing.T, home string) {
+	t.Helper()
+
+	cfg, err := files.NewConfigFile(home)
+	if err != nil {
+		t.Fatalf("NewConfigFile() error = %v", err)
+	}
+	cfgSection, err := cfg.File.NewSection("profile dev:auto")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = cfgSection.NewKey("org", "dev")
+	_, _ = cfgSection.NewKey("sso_auto_populated", "true")
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() config error = %v", err)
+	}
+
+	creds, err := files.NewCredentialsFile(home)
+	if err != nil {
+		t.Fatalf("NewCredentialsFile() error = %v", err)
+	}
+	addCredentialSection(t, creds, "tmp:dev:expired", "dev", "100")
+	addCredentialSection(t, creds, "tmp:dev:active", "dev", "4102444800")
+	if err := creds.Save(); err != nil {
+		t.Fatalf("Save() credentials error = %v", err)
+	}
+}
+
+func createCrossOrgCredentialsFixture(t *testing.T, home string) {
+	t.Helper()
+
+	creds, err := files.NewCredentialsFile(home)
+	if err != nil {
+		t.Fatalf("NewCredentialsFile() error = %v", err)
+	}
+	addCredentialSection(t, creds, "tmp:prod:expired", "prod", "50")
+	addCredentialSection(t, creds, "tmp:prod:active", "prod", "4102444800")
+	if err := creds.Save(); err != nil {
+		t.Fatalf("Save() additional credentials error = %v", err)
+	}
+}
+
+func addCredentialSection(t *testing.T, file *files.AWSFile, name, org, expires string) {
+	t.Helper()
+
+	section, err := file.File.NewSection(name)
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = section.NewKey("org", org)
+	_, _ = section.NewKey("sso_auto_populated", "true")
+	if expires != "" {
+		_, _ = section.NewKey("expires_time", expires)
+	}
+}
+
+func logCredentialSections(t *testing.T, path, label string) {
+	t.Helper()
+
+	file, err := ini.Load(path)
+	if err != nil {
+		t.Fatalf("ini.Load(%q) error = %v", path, err)
+	}
+	t.Logf("%s %s sections:", label, path)
+	for _, section := range file.SectionStrings() {
+		t.Log(section)
+	}
+}
+
+func assertSectionPresent(t *testing.T, path, section string) {
+	t.Helper()
+
+	file, err := ini.Load(path)
+	if err != nil {
+		t.Fatalf("ini.Load(%q) error = %v", path, err)
+	}
+	if _, err := file.GetSection(section); err != nil {
+		t.Fatalf("expected section %q in %s, got %v", section, path, err)
+	}
+}
+
+func assertSectionMissing(t *testing.T, path, section string) {
+	t.Helper()
+
+	file, err := ini.Load(path)
+	if err != nil {
+		t.Fatalf("ini.Load(%q) error = %v", path, err)
+	}
+	if _, err := file.GetSection(section); err == nil {
+		t.Fatalf("section %q still present in %s", section, path)
+	}
+}

--- a/cmd/aws-sso-creds/select.go
+++ b/cmd/aws-sso-creds/select.go
@@ -1,10 +1,13 @@
 package awsssocreds
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/JorgeReus/aws-sso-creds/internal/app/config"
 	"github.com/JorgeReus/aws-sso-creds/internal/pkg/ui"
+	"github.com/ktr0731/go-fuzzyfinder"
 	"github.com/spf13/cobra"
 )
 
@@ -13,9 +16,10 @@ type previewer interface {
 }
 
 type selectDeps struct {
-	initConfig         func(home, configPath string) error
-	newFuzzyPreviewer  func(credentialsPath string, configFilePath string) (previewer, error)
-	println            func(...interface{}) (int, error)
+	initConfig        func(home, configPath string) error
+	newFuzzyPreviewer func(credentialsPath string, configFilePath string) (previewer, error)
+	println           func(...interface{}) (int, error)
+	getenv            func(string) string
 }
 
 var selectDepsFactory = defaultSelectDeps
@@ -27,6 +31,7 @@ func defaultSelectDeps() selectDeps {
 			return ui.NewFuzzyPreviewer(credentialsPath, configFilePath)
 		},
 		println: fmt.Println,
+		getenv:  os.Getenv,
 	}
 }
 
@@ -49,7 +54,17 @@ func newSelectCmd(deps selectDeps) *cobra.Command {
 			}
 			selectedEntry, err := fp.Preview()
 			if err != nil {
+				if errors.Is(err, fuzzyfinder.ErrAbort) {
+					if profile := deps.getenv("AWS_PROFILE"); profile != "" {
+						_, err = deps.println(profile)
+						return err
+					}
+					return nil
+				}
 				return fmt.Errorf("Error selecting entry: %w", err)
+			}
+			if selectedEntry == nil {
+				return fmt.Errorf("Error selecting entry: %w", errors.New("no profile selected"))
 			}
 			_, err = deps.println(*selectedEntry)
 			return err

--- a/cmd/aws-sso-creds/select_test.go
+++ b/cmd/aws-sso-creds/select_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/JorgeReus/aws-sso-creds/internal/app/config"
+	"github.com/ktr0731/go-fuzzyfinder"
 )
 
 type fakePreviewer struct {
@@ -32,6 +33,7 @@ func TestSelectCommandInvokesPreviewerFlow(t *testing.T) {
 			printed = args[0].(string)
 			return 0, nil
 		},
+		getenv: func(string) string { return "" },
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -54,6 +56,7 @@ func TestSelectCommandReturnsPreviewerCreationError(t *testing.T) {
 			return nil, wantErr
 		},
 		println: func(args ...interface{}) (int, error) { return 0, nil },
+		getenv:  func(string) string { return "" },
 	})
 
 	err := cmd.Execute()
@@ -74,6 +77,7 @@ func TestSelectCommandReturnsPreviewError(t *testing.T) {
 			return fakePreviewer{err: wantErr}, nil
 		},
 		println: func(args ...interface{}) (int, error) { return 0, nil },
+		getenv:  func(string) string { return "" },
 	})
 
 	err := cmd.Execute()
@@ -82,9 +86,41 @@ func TestSelectCommandReturnsPreviewError(t *testing.T) {
 	}
 }
 
+func TestSelectCommandReturnsEnvValueOnAbort(t *testing.T) {
+	const profile = "dev:account:Admin"
+	var printed string
+	cmd := newSelectCmd(selectDeps{
+		initConfig: func(home, configPath string) error {
+			config.ResetForTest()
+			config.SetInstanceForTest(&config.Config{Home: "/tmp"})
+			return nil
+		},
+		newFuzzyPreviewer: func(credentialsPath string, configFilePath string) (previewer, error) {
+			return fakePreviewer{err: fuzzyfinder.ErrAbort}, nil
+		},
+		println: func(args ...interface{}) (int, error) {
+			printed = args[0].(string)
+			return 0, nil
+		},
+		getenv: func(key string) string {
+			if key != "AWS_PROFILE" {
+				t.Fatalf("unexpected getenv key %q", key)
+			}
+			return profile
+		},
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if printed != profile {
+		t.Fatalf("printed = %q, want %q", printed, profile)
+	}
+}
+
 func TestDefaultSelectDepsProvidesFunctions(t *testing.T) {
 	deps := defaultSelectDeps()
-	if deps.initConfig == nil || deps.newFuzzyPreviewer == nil || deps.println == nil {
+	if deps.initConfig == nil || deps.newFuzzyPreviewer == nil || deps.println == nil || deps.getenv == nil {
 		t.Fatal("defaultSelectDeps() returned nil dependency")
 	}
 }

--- a/internal/pkg/files/files.go
+++ b/internal/pkg/files/files.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	pathpkg "path/filepath"
+	"strconv"
 
 	"gopkg.in/ini.v1"
 )
@@ -58,7 +59,7 @@ func IsValidEntry(s *ini.Section, organization string) bool {
 	if err != nil {
 		return false
 	}
-	if s.HasKey("sso_auto_populated") && org.String() == organization {
+	if s.HasKey("sso_auto_populated") && (organization == "" || org.String() == organization) {
 		return true
 	}
 
@@ -100,9 +101,36 @@ func (f *AWSFile) Save() error {
 }
 
 func (c *AWSFile) CleanTemporaryRoles(organization string) {
+	sections := make([]string, 0)
 	for _, section := range c.File.Sections() {
 		if IsValidEntry(section, organization) {
-			c.File.DeleteSection(section.Name())
+			sections = append(sections, section.Name())
 		}
+	}
+	for _, section := range sections {
+		c.File.DeleteSection(section)
+	}
+}
+
+func (c *AWSFile) CleanExpiredCredentials(organization string, nowUnix int64) {
+	sections := make([]string, 0)
+	for _, section := range c.File.Sections() {
+		if !IsValidEntry(section, organization) {
+			continue
+		}
+		expiresTime, err := section.GetKey("expires_time")
+		if err != nil {
+			continue
+		}
+		expiresUnix, err := strconv.ParseInt(expiresTime.String(), 10, 64)
+		if err != nil {
+			continue
+		}
+		if expiresUnix < nowUnix {
+			sections = append(sections, section.Name())
+		}
+	}
+	for _, section := range sections {
+		c.File.DeleteSection(section)
 	}
 }

--- a/internal/pkg/files/files_test.go
+++ b/internal/pkg/files/files_test.go
@@ -8,12 +8,57 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-func TestConfigAndCredentialsHelpersManageAutoPopulatedEntries(t *testing.T) {
+type sectionSpec struct {
+	name string
+	keys map[string]string
+}
+
+func addSections(t *testing.T, cfg *AWSFile, specs []sectionSpec) {
+	t.Helper()
+	for _, spec := range specs {
+		section, err := cfg.File.NewSection(spec.name)
+		if err != nil {
+			t.Fatalf("NewSection(%s) error = %v", spec.name, err)
+		}
+		for key, value := range spec.keys {
+			if _, err := section.NewKey(key, value); err != nil {
+				t.Fatalf("NewKey(%s=%s) error = %v", key, value, err)
+			}
+		}
+	}
+}
+
+func mustConfigFile(t *testing.T) (*AWSFile, string) {
+	t.Helper()
 	home := t.TempDir()
-	err := os.MkdirAll(filepath.Join(home, ".aws"), 0o755)
+	cfg, err := NewConfigFile(home)
 	if err != nil {
+		t.Fatalf("NewConfigFile() error = %v", err)
+	}
+	return cfg, home
+}
+
+func assertSectionState(t *testing.T, cfg *AWSFile, name string, shouldExist bool) {
+	t.Helper()
+	_, err := cfg.File.GetSection(name)
+	if shouldExist && err != nil {
+		t.Fatalf("expected section %q to exist: %v", name, err)
+	}
+	if !shouldExist && err == nil {
+		t.Fatalf("expected section %q to be removed", name)
+	}
+}
+
+func ensureDir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
+}
+
+func TestConfigAndCredentialsHelpersManageAutoPopulatedEntries(t *testing.T) {
+	home := t.TempDir()
+	ensureDir(t, filepath.Join(home, ".aws"))
 
 	configFile, err := NewConfigFile(home)
 	if err != nil {
@@ -31,306 +76,339 @@ func TestConfigAndCredentialsHelpersManageAutoPopulatedEntries(t *testing.T) {
 		t.Fatalf("Save() error = %v", err)
 	}
 
-	if ConfigFileSSOEmpty(home, "dev") {
-		t.Fatal("ConfigFileSSOEmpty() = true, want false")
+	cases := []struct {
+		name string
+		run  func(t *testing.T) bool
+		want bool
+	}{
+		{
+			name: "before cleanup",
+			run: func(t *testing.T) bool {
+				return ConfigFileSSOEmpty(home, "dev")
+			},
+			want: false,
+		},
+		{
+			name: "after cleanup",
+			run: func(t *testing.T) bool {
+				configFile.CleanTemporaryRoles("dev")
+				if err := configFile.Save(); err != nil {
+					t.Fatalf("Save() after cleanup error = %v", err)
+				}
+				return ConfigFileSSOEmpty(home, "dev")
+			},
+			want: true,
+		},
 	}
 
-	configFile.CleanTemporaryRoles("dev")
-	if err := configFile.Save(); err != nil {
-		t.Fatalf("Save() after cleanup error = %v", err)
-	}
-	if !ConfigFileSSOEmpty(home, "dev") {
-		t.Fatal("ConfigFileSSOEmpty() = false, want true after cleanup")
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.run(t); got != tt.want {
+				t.Fatalf("ConfigFileSSOEmpty() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestGetentryByAWSProfileReturnsExpectedSection(t *testing.T) {
-	home := t.TempDir()
-	err := os.MkdirAll(filepath.Join(home, ".aws"), 0o755)
-	if err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
+func TestGetentryByAWSProfile(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  string
+		setup    func(*AWSFile) error
+		wantName string
+		wantErr  bool
+	}{
+		{
+			name:    "returns expected section",
+			profile: "dev:account:Admin",
+			setup: func(cfg *AWSFile) error {
+				if _, err := cfg.File.NewSection("profile dev:account:Admin"); err != nil {
+					return err
+				}
+				return nil
+			},
+			wantName: "profile dev:account:Admin",
+		},
+		{
+			name:    "errors when section missing",
+			profile: "missing",
+			wantErr: true,
+		},
 	}
 
-	configFile, err := NewConfigFile(home)
-	if err != nil {
-		t.Fatalf("NewConfigFile() error = %v", err)
-	}
-	_, err = configFile.File.NewSection("profile dev:account:Admin")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, _ := mustConfigFile(t)
+			if tt.setup != nil {
+				if err := tt.setup(cfg); err != nil {
+					t.Fatalf("setup error = %v", err)
+				}
+			}
 
-	section, err := configFile.GetentryByAWSProfile("dev:account:Admin")
-	if err != nil {
-		t.Fatalf("GetentryByAWSProfile() error = %v", err)
-	}
-	if section.Name() != "profile dev:account:Admin" {
-		t.Fatalf("section.Name() = %q, want %q", section.Name(), "profile dev:account:Admin")
+			section, err := cfg.GetentryByAWSProfile(tt.profile)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("GetentryByAWSProfile() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetentryByAWSProfile() error = %v", err)
+			}
+			if section.Name() != tt.wantName {
+				t.Fatalf("section.Name() = %q, want %q", section.Name(), tt.wantName)
+			}
+		})
 	}
 }
 
-func TestNewCredentialsFileCreatesCredentialsPath(t *testing.T) {
-	home := t.TempDir()
-	err := os.MkdirAll(filepath.Join(home, ".aws"), 0o755)
-	if err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
+func TestNewAWSFileCreation(t *testing.T) {
+	tests := []struct {
+		name    string
+		create  func(string) (string, error)
+		wantRel string
+	}{
+		{
+			name: "config file creates aws directory",
+			create: func(home string) (string, error) {
+				cfg, err := NewConfigFile(home)
+				if err != nil {
+					return "", err
+				}
+				return cfg.Path, nil
+			},
+			wantRel: filepath.Join(".aws", "config"),
+		},
+		{
+			name: "credentials file returns expected path",
+			create: func(home string) (string, error) {
+				cfg, err := NewCredentialsFile(home)
+				if err != nil {
+					return "", err
+				}
+				return cfg.Path, nil
+			},
+			wantRel: filepath.Join(".aws", "credentials"),
+		},
 	}
 
-	credentialsFile, err := NewCredentialsFile(home)
-	if err != nil {
-		t.Fatalf("NewCredentialsFile() error = %v", err)
-	}
-	if credentialsFile.Path != filepath.Join(home, ".aws", "credentials") {
-		t.Fatalf("Path = %q, want %q", credentialsFile.Path, filepath.Join(home, ".aws", "credentials"))
-	}
-	if _, err := os.Stat(credentialsFile.Path); err != nil {
-		t.Fatalf("credentials file stat error = %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			path, err := tt.create(home)
+			if err != nil {
+				t.Fatalf("create error = %v", err)
+			}
+			want := filepath.Join(home, tt.wantRel)
+			if path != want {
+				t.Fatalf("Path = %q, want %q", path, want)
+			}
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("file stat error = %v", err)
+			}
+		})
 	}
 }
 
-func TestNewConfigFileCreatesAWSDirectoryWhenMissing(t *testing.T) {
-	home := t.TempDir()
-
-	configFile, err := NewConfigFile(home)
-	if err != nil {
-		t.Fatalf("NewConfigFile() error = %v", err)
-	}
-	if configFile.Path != filepath.Join(home, ".aws", "config") {
-		t.Fatalf("Path = %q, want %q", configFile.Path, filepath.Join(home, ".aws", "config"))
-	}
-	if _, err := os.Stat(configFile.Path); err != nil {
-		t.Fatalf("config file stat error = %v", err)
-	}
-}
-
-func TestNewCredentialsFileCreatesAWSDirectoryWhenMissing(t *testing.T) {
-	home := t.TempDir()
-
-	credentialsFile, err := NewCredentialsFile(home)
-	if err != nil {
-		t.Fatalf("NewCredentialsFile() error = %v", err)
-	}
-	if credentialsFile.Path != filepath.Join(home, ".aws", "credentials") {
-		t.Fatalf("Path = %q, want %q", credentialsFile.Path, filepath.Join(home, ".aws", "credentials"))
-	}
-	if _, err := os.Stat(credentialsFile.Path); err != nil {
-		t.Fatalf("credentials file stat error = %v", err)
-	}
-}
-
-func TestConfigFileSSOEmptyReturnsTrueForInvalidConfig(t *testing.T) {
-	home := t.TempDir()
-	awsDir := filepath.Join(home, ".aws")
-	if err := os.MkdirAll(awsDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	configPath := filepath.Join(awsDir, "config")
-	if err := os.WriteFile(configPath, []byte("[profile broken\norg=dev\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
+func TestConfigFileSSOEmptyReturnsTrueForInvalidConfigs(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{
+			name:     "missing section bracket",
+			contents: "[profile broken\norg=dev\n",
+		},
+		{
+			name:     "malformed key",
+			contents: "[profile broken]\norg",
+		},
 	}
 
-	if !ConfigFileSSOEmpty(home, "dev") {
-		t.Fatal("ConfigFileSSOEmpty() = false, want true for invalid config")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			awsDir := filepath.Join(home, ".aws")
+			ensureDir(t, awsDir)
+			configPath := filepath.Join(awsDir, "config")
+			if err := os.WriteFile(configPath, []byte(tt.contents), 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+			if !ConfigFileSSOEmpty(home, "dev") {
+				t.Fatal("ConfigFileSSOEmpty() = false, want true for invalid config")
+			}
+		})
 	}
 }
 
 func TestIsValidEntryRequiresOrganizationAndAutoPopulatedKey(t *testing.T) {
-	file := ini.Empty()
-	withOrg, err := file.NewSection("profile dev")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = withOrg.NewKey("org", "dev")
-	_, _ = withOrg.NewKey("sso_auto_populated", "true")
-	if !IsValidEntry(withOrg, "dev") {
-		t.Fatal("IsValidEntry() = false, want true")
-	}
-	if IsValidEntry(withOrg, "prod") {
-		t.Fatal("IsValidEntry() = true, want false for mismatched org")
+	tests := []struct {
+		name        string
+		sectionName string
+		keys        map[string]string
+		profile     string
+		want        bool
+	}{
+		{
+			name:        "valid entry",
+			sectionName: "profile dev",
+			keys: map[string]string{
+				"org":                "dev",
+				"sso_auto_populated": "true",
+			},
+			profile: "dev",
+			want:    true,
+		},
+		{
+			name:        "mismatched organization",
+			sectionName: "profile mismatched",
+			keys: map[string]string{
+				"org":                "dev",
+				"sso_auto_populated": "true",
+			},
+			profile: "prod",
+			want:    false,
+		},
+		{
+			name:        "missing auto-populated",
+			sectionName: "profile no-auto",
+			keys: map[string]string{
+				"org": "dev",
+			},
+			profile: "dev",
+			want:    false,
+		},
+		{
+			name:        "missing organization",
+			sectionName: "profile no-org",
+			keys: map[string]string{
+				"sso_auto_populated": "true",
+			},
+			profile: "dev",
+			want:    false,
+		},
 	}
 
-	missingAuto, err := file.NewSection("profile no-auto")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = missingAuto.NewKey("org", "dev")
-	if IsValidEntry(missingAuto, "dev") {
-		t.Fatal("IsValidEntry() = true, want false without sso_auto_populated")
-	}
-
-	missingOrg, err := file.NewSection("profile no-org")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = missingOrg.NewKey("sso_auto_populated", "true")
-	if IsValidEntry(missingOrg, "dev") {
-		t.Fatal("IsValidEntry() = true, want false without org")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := ini.Empty()
+			section, err := file.NewSection(tt.sectionName)
+			if err != nil {
+				t.Fatalf("NewSection() error = %v", err)
+			}
+			for key, value := range tt.keys {
+				if _, err := section.NewKey(key, value); err != nil {
+					t.Fatalf("NewKey(%s=%s) error = %v", key, value, err)
+				}
+			}
+			if got := IsValidEntry(section, tt.profile); got != tt.want {
+				t.Fatalf("IsValidEntry() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestGetentryByAWSProfileReturnsErrorForMissingSection(t *testing.T) {
-	home := t.TempDir()
-	configFile, err := NewConfigFile(home)
-	if err != nil {
-		t.Fatalf("NewConfigFile() error = %v", err)
+func TestCleanTemporaryRoles(t *testing.T) {
+	tests := []struct {
+		name      string
+		org       string
+		sections  []sectionSpec
+		wantState map[string]bool
+	}{
+		{
+			name: "removes matching organization entries",
+			org:  "dev",
+			sections: []sectionSpec{
+				{name: "profile keep-other-org", keys: map[string]string{"org": "prod", "sso_auto_populated": "true"}},
+				{name: "profile keep-manual", keys: map[string]string{"org": "dev"}},
+				{name: "profile remove-match", keys: map[string]string{"org": "dev", "sso_auto_populated": "true"}},
+			},
+			wantState: map[string]bool{
+				"profile keep-other-org": true,
+				"profile keep-manual":    true,
+				"profile remove-match":   false,
+			},
+		},
+		{
+			name: "removes all auto-populated entries",
+			org:  "",
+			sections: []sectionSpec{
+				{name: "profile keep-manual", keys: map[string]string{"org": "dev"}},
+				{name: "profile remove-dev", keys: map[string]string{"org": "dev", "sso_auto_populated": "true"}},
+				{name: "profile remove-prod", keys: map[string]string{"org": "prod", "sso_auto_populated": "true"}},
+			},
+			wantState: map[string]bool{
+				"profile keep-manual": true,
+				"profile remove-dev":  false,
+				"profile remove-prod": false,
+			},
+		},
 	}
 
-	if _, err := configFile.GetentryByAWSProfile("missing"); err == nil {
-		t.Fatal("GetentryByAWSProfile() error = nil, want error")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, _ := mustConfigFile(t)
+			addSections(t, cfg, tt.sections)
+			cfg.CleanTemporaryRoles(tt.org)
+			for sectionName, shouldExist := range tt.wantState {
+				assertSectionState(t, cfg, sectionName, shouldExist)
+			}
+		})
 	}
 }
 
-func TestCleanTemporaryRolesRemovesOnlyMatchingOrganization(t *testing.T) {
-	home := t.TempDir()
-	configFile, err := NewConfigFile(home)
-	if err != nil {
-		t.Fatalf("NewConfigFile() error = %v", err)
+func TestCleanExpiredCredentials(t *testing.T) {
+	tests := []struct {
+		name      string
+		org       string
+		cutoff    int64
+		sections  []sectionSpec
+		wantState map[string]bool
+	}{
+		{
+			name:   "removes only expired matching sections",
+			org:    "dev",
+			cutoff: 150,
+			sections: []sectionSpec{
+				{name: "profile expired-dev", keys: map[string]string{"org": "dev", "sso_auto_populated": "true", "expires_time": "100"}},
+				{name: "profile active-dev", keys: map[string]string{"org": "dev", "sso_auto_populated": "true", "expires_time": "200"}},
+				{name: "profile expired-prod", keys: map[string]string{"org": "prod", "sso_auto_populated": "true", "expires_time": "50"}},
+				{name: "profile manual-expired", keys: map[string]string{"org": "dev", "expires_time": "25"}},
+				{name: "profile invalid-expiration", keys: map[string]string{"org": "dev", "sso_auto_populated": "true", "expires_time": "bad"}},
+				{name: "profile missing-expiration", keys: map[string]string{"org": "dev", "sso_auto_populated": "true"}},
+			},
+			wantState: map[string]bool{
+				"profile expired-dev":        false,
+				"profile active-dev":         true,
+				"profile expired-prod":       true,
+				"profile manual-expired":     true,
+				"profile invalid-expiration": true,
+				"profile missing-expiration": true,
+			},
+		},
+		{
+			name:   "keeps entries when cutoff before expiration",
+			org:    "dev",
+			cutoff: 50,
+			sections: []sectionSpec{
+				{name: "profile future-dev", keys: map[string]string{"org": "dev", "sso_auto_populated": "true", "expires_time": "500"}},
+				{name: "profile future-prod", keys: map[string]string{"org": "prod", "sso_auto_populated": "true", "expires_time": "500"}},
+			},
+			wantState: map[string]bool{
+				"profile future-dev":  true,
+				"profile future-prod": true,
+			},
+		},
 	}
 
-	keepOtherOrg, err := configFile.File.NewSection("profile keep-other-org")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = keepOtherOrg.NewKey("org", "prod")
-	_, _ = keepOtherOrg.NewKey("sso_auto_populated", "true")
-
-	keepManual, err := configFile.File.NewSection("profile keep-manual")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = keepManual.NewKey("org", "dev")
-
-	removeMatch, err := configFile.File.NewSection("profile remove-match")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = removeMatch.NewKey("org", "dev")
-	_, _ = removeMatch.NewKey("sso_auto_populated", "true")
-
-	configFile.CleanTemporaryRoles("dev")
-
-	if _, err := configFile.File.GetSection("profile remove-match"); err == nil {
-		t.Fatal("matched auto-populated section was not removed")
-	}
-	if _, err := configFile.File.GetSection("profile keep-other-org"); err != nil {
-		t.Fatal("non-matching org section was removed")
-	}
-	if _, err := configFile.File.GetSection("profile keep-manual"); err != nil {
-		t.Fatal("manual section was removed")
-	}
-}
-
-func TestCleanTemporaryRolesAllOrganizationsRemovesOnlyAutoPopulatedSections(t *testing.T) {
-	home := t.TempDir()
-	configFile, err := NewConfigFile(home)
-	if err != nil {
-		t.Fatalf("NewConfigFile() error = %v", err)
-	}
-
-	keepManual, err := configFile.File.NewSection("profile keep-manual")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = keepManual.NewKey("org", "dev")
-
-	removeDev, err := configFile.File.NewSection("profile remove-dev")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = removeDev.NewKey("org", "dev")
-	_, _ = removeDev.NewKey("sso_auto_populated", "true")
-
-	removeProd, err := configFile.File.NewSection("profile remove-prod")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = removeProd.NewKey("org", "prod")
-	_, _ = removeProd.NewKey("sso_auto_populated", "true")
-
-	configFile.CleanTemporaryRoles("")
-
-	if _, err := configFile.File.GetSection("profile remove-dev"); err == nil {
-		t.Fatal("dev auto-populated section was not removed")
-	}
-	if _, err := configFile.File.GetSection("profile remove-prod"); err == nil {
-		t.Fatal("prod auto-populated section was not removed")
-	}
-	if _, err := configFile.File.GetSection("profile keep-manual"); err != nil {
-		t.Fatal("manual section was removed")
-	}
-}
-
-func TestCleanExpiredCredentialsRemovesOnlyExpiredMatchingSections(t *testing.T) {
-	home := t.TempDir()
-	configFile, err := NewConfigFile(home)
-	if err != nil {
-		t.Fatalf("NewConfigFile() error = %v", err)
-	}
-
-	expiredDev, err := configFile.File.NewSection("profile expired-dev")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = expiredDev.NewKey("org", "dev")
-	_, _ = expiredDev.NewKey("sso_auto_populated", "true")
-	_, _ = expiredDev.NewKey("expires_time", "100")
-
-	activeDev, err := configFile.File.NewSection("profile active-dev")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = activeDev.NewKey("org", "dev")
-	_, _ = activeDev.NewKey("sso_auto_populated", "true")
-	_, _ = activeDev.NewKey("expires_time", "200")
-
-	otherOrgExpired, err := configFile.File.NewSection("profile expired-prod")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = otherOrgExpired.NewKey("org", "prod")
-	_, _ = otherOrgExpired.NewKey("sso_auto_populated", "true")
-	_, _ = otherOrgExpired.NewKey("expires_time", "50")
-
-	manualExpired, err := configFile.File.NewSection("profile manual-expired")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = manualExpired.NewKey("org", "dev")
-	_, _ = manualExpired.NewKey("expires_time", "25")
-
-	invalidExpiration, err := configFile.File.NewSection("profile invalid-expiration")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = invalidExpiration.NewKey("org", "dev")
-	_, _ = invalidExpiration.NewKey("sso_auto_populated", "true")
-	_, _ = invalidExpiration.NewKey("expires_time", "bad")
-
-	missingExpiration, err := configFile.File.NewSection("profile missing-expiration")
-	if err != nil {
-		t.Fatalf("NewSection() error = %v", err)
-	}
-	_, _ = missingExpiration.NewKey("org", "dev")
-	_, _ = missingExpiration.NewKey("sso_auto_populated", "true")
-
-	configFile.CleanExpiredCredentials("dev", 150)
-
-	if _, err := configFile.File.GetSection("profile expired-dev"); err == nil {
-		t.Fatal("expired matching section was not removed")
-	}
-	if _, err := configFile.File.GetSection("profile active-dev"); err != nil {
-		t.Fatal("active matching section was removed")
-	}
-	if _, err := configFile.File.GetSection("profile expired-prod"); err != nil {
-		t.Fatal("other-org section was removed")
-	}
-	if _, err := configFile.File.GetSection("profile manual-expired"); err != nil {
-		t.Fatal("manual section was removed")
-	}
-	if _, err := configFile.File.GetSection("profile invalid-expiration"); err != nil {
-		t.Fatal("invalid-expiration section was removed")
-	}
-	if _, err := configFile.File.GetSection("profile missing-expiration"); err != nil {
-		t.Fatal("missing-expiration section was removed")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, _ := mustConfigFile(t)
+			addSections(t, cfg, tt.sections)
+			cfg.CleanExpiredCredentials(tt.org, tt.cutoff)
+			for sectionName, shouldExist := range tt.wantState {
+				assertSectionState(t, cfg, sectionName, shouldExist)
+			}
+		})
 	}
 }

--- a/internal/pkg/files/files_test.go
+++ b/internal/pkg/files/files_test.go
@@ -219,3 +219,118 @@ func TestCleanTemporaryRolesRemovesOnlyMatchingOrganization(t *testing.T) {
 		t.Fatal("manual section was removed")
 	}
 }
+
+func TestCleanTemporaryRolesAllOrganizationsRemovesOnlyAutoPopulatedSections(t *testing.T) {
+	home := t.TempDir()
+	configFile, err := NewConfigFile(home)
+	if err != nil {
+		t.Fatalf("NewConfigFile() error = %v", err)
+	}
+
+	keepManual, err := configFile.File.NewSection("profile keep-manual")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = keepManual.NewKey("org", "dev")
+
+	removeDev, err := configFile.File.NewSection("profile remove-dev")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = removeDev.NewKey("org", "dev")
+	_, _ = removeDev.NewKey("sso_auto_populated", "true")
+
+	removeProd, err := configFile.File.NewSection("profile remove-prod")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = removeProd.NewKey("org", "prod")
+	_, _ = removeProd.NewKey("sso_auto_populated", "true")
+
+	configFile.CleanTemporaryRoles("")
+
+	if _, err := configFile.File.GetSection("profile remove-dev"); err == nil {
+		t.Fatal("dev auto-populated section was not removed")
+	}
+	if _, err := configFile.File.GetSection("profile remove-prod"); err == nil {
+		t.Fatal("prod auto-populated section was not removed")
+	}
+	if _, err := configFile.File.GetSection("profile keep-manual"); err != nil {
+		t.Fatal("manual section was removed")
+	}
+}
+
+func TestCleanExpiredCredentialsRemovesOnlyExpiredMatchingSections(t *testing.T) {
+	home := t.TempDir()
+	configFile, err := NewConfigFile(home)
+	if err != nil {
+		t.Fatalf("NewConfigFile() error = %v", err)
+	}
+
+	expiredDev, err := configFile.File.NewSection("profile expired-dev")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = expiredDev.NewKey("org", "dev")
+	_, _ = expiredDev.NewKey("sso_auto_populated", "true")
+	_, _ = expiredDev.NewKey("expires_time", "100")
+
+	activeDev, err := configFile.File.NewSection("profile active-dev")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = activeDev.NewKey("org", "dev")
+	_, _ = activeDev.NewKey("sso_auto_populated", "true")
+	_, _ = activeDev.NewKey("expires_time", "200")
+
+	otherOrgExpired, err := configFile.File.NewSection("profile expired-prod")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = otherOrgExpired.NewKey("org", "prod")
+	_, _ = otherOrgExpired.NewKey("sso_auto_populated", "true")
+	_, _ = otherOrgExpired.NewKey("expires_time", "50")
+
+	manualExpired, err := configFile.File.NewSection("profile manual-expired")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = manualExpired.NewKey("org", "dev")
+	_, _ = manualExpired.NewKey("expires_time", "25")
+
+	invalidExpiration, err := configFile.File.NewSection("profile invalid-expiration")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = invalidExpiration.NewKey("org", "dev")
+	_, _ = invalidExpiration.NewKey("sso_auto_populated", "true")
+	_, _ = invalidExpiration.NewKey("expires_time", "bad")
+
+	missingExpiration, err := configFile.File.NewSection("profile missing-expiration")
+	if err != nil {
+		t.Fatalf("NewSection() error = %v", err)
+	}
+	_, _ = missingExpiration.NewKey("org", "dev")
+	_, _ = missingExpiration.NewKey("sso_auto_populated", "true")
+
+	configFile.CleanExpiredCredentials("dev", 150)
+
+	if _, err := configFile.File.GetSection("profile expired-dev"); err == nil {
+		t.Fatal("expired matching section was not removed")
+	}
+	if _, err := configFile.File.GetSection("profile active-dev"); err != nil {
+		t.Fatal("active matching section was removed")
+	}
+	if _, err := configFile.File.GetSection("profile expired-prod"); err != nil {
+		t.Fatal("other-org section was removed")
+	}
+	if _, err := configFile.File.GetSection("profile manual-expired"); err != nil {
+		t.Fatal("manual section was removed")
+	}
+	if _, err := configFile.File.GetSection("profile invalid-expiration"); err != nil {
+		t.Fatal("invalid-expiration section was removed")
+	}
+	if _, err := configFile.File.GetSection("profile missing-expiration"); err != nil {
+		t.Fatal("missing-expiration section was removed")
+	}
+}


### PR DESCRIPTION
**Fix: Keep AWS_PROFILE when fuzzy finder aborts**
  Prevent aws-sso-creds select from clearing an existing AWS_PROFILE if the fuzzy picker is interrupted by wrapping the abort error, reprinting the current profile, and adding dependency/test coverage for the new behavior.

  **Feat: Implemented clean subcommand**
  Added the clean command to prune expired credentials/config sections and wired its configuration/fixtures around the new organization cleanup flow.